### PR TITLE
Multiple counter support

### DIFF
--- a/obs_count_things.py
+++ b/obs_count_things.py
@@ -1,9 +1,11 @@
 import obspython as obs
-from os.path import exists
+from os.path import exists, dirname
+import os
 
 
 class TextContent:
-    def __init__(self, source_name=None, text_string="This is default text"):
+    def __init__(self, counter_name="Default", source_name=None, text_string="This is default text"):
+        self.counter_name = counter_name
         self.source_name = source_name
         self.text_string = text_string
         self.counter = 0
@@ -11,30 +13,32 @@ class TextContent:
         obs.script_log(obs.LOG_INFO, f"Initializing TextContent with counter of {self.counter}")
 
     def set_counter(self, count):
-        print(f"Setting counter to {count}")
         self.counter = count
 
     def update_text(self, counter_text, counter_value=0):
         source = obs.obs_get_source_by_name(self.source_name)
         settings = obs.obs_data_create()
 
-        if counter_value == 1:
-            self.counter += 1
-
-        elif counter_value == -1:
-            self.counter -= 1
-
-        elif counter_value == 0:
+        self.counter += counter_value
+        if counter_value == 0:  # Reset case
             self.counter = 0
 
         self.text_string = f"{counter_text}{self.counter:,}"
 
         try:
-            print(f"Writing new saved counter to settings file of {self.counter}")
-            with open(self.counter_save_path, 'w+') as f:
-                f.write(str(self.counter))
-        except:
-            print("ERROR: Something went wrong trying to save new counter value")
+            if exists(self.counter_save_path):
+                with open(self.counter_save_path) as f:
+                    counters = dict(line.strip().split(': ', 1) for line in f if ': ' in line)
+            else:
+                counters = {}
+            
+            counters[self.counter_name] = str(self.counter)
+            
+            with open(self.counter_save_path, 'w') as f:
+                f.writelines(f"{name}: {value}\n" for name, value in counters.items())
+                
+        except Exception as e:
+            print(f"Error saving counter: {e}")
 
         obs.obs_data_set_string(settings, "text", self.text_string)
         obs.obs_source_update(source, settings)
@@ -110,64 +114,79 @@ def callback_reset(pressed):
     if pressed:
         return hotkeys_counter.reset()
 
+def get_available_counters(save_path):
+    counters = []
+    try:
+        if exists(save_path):
+            with open(save_path, "r") as f:
+                for line in f:
+                    if ':' in line:
+                        counter_name = line.split(':')[0].strip()
+                        if counter_name:
+                            counters.append(counter_name)
+    except Exception as e:
+        print(f"Error reading counters from save file: {str(e)}")
+    return counters
+
 
 def script_description():
     return "We count things via OBS hotkey. See github.com/RetroTGaming/OBS-Count-Things for instructions"
 
 
 def script_update(settings):
+    hotkeys_counter.counter_name = obs.obs_data_get_string(settings, "counter_selection") or obs.obs_data_get_string(settings, "counter_name")
     hotkeys_counter.source_name = obs.obs_data_get_string(settings, "source")
     hotkeys_counter.counter_text = obs.obs_data_get_string(settings, "counter_text")
-    hotkeys_counter.counter_save_path = f"{obs.obs_data_get_string(settings, 'counter_save_path')}\\obs_count_things_counter.txt"
+    save_path = obs.obs_data_get_string(settings, 'counter_save_path') or dirname(os.path.realpath(__file__))
+    hotkeys_counter.counter_save_path = f"{save_path}\\obs_count_things_counter.txt"
 
-    if hotkeys_counter.counter_save_path is None or str(hotkeys_counter.counter_save_path).strip() == "":
-        print("Got no save path, will initialize using 0")
+    try:
+        if not exists(hotkeys_counter.counter_save_path):
+            with open(hotkeys_counter.counter_save_path, 'w') as f:
+                f.write(f"{hotkeys_counter.counter_name}: 0")
+            return
 
-    else:
-        print(f"Got save path of {hotkeys_counter.counter_save_path}")
+        with open(hotkeys_counter.counter_save_path) as f:
+            counters = dict(line.strip().split(': ', 1) for line in f if ': ' in line)
+            value = int(counters.get(hotkeys_counter.counter_name, 0))
+            hotkeys_counter.set_counter(value)
+            print(f"Loaded counter '{hotkeys_counter.counter_name}' with value {value}")
 
-        try:
-            if exists(hotkeys_counter.counter_save_path):
-                with open(hotkeys_counter.counter_save_path, "r") as f:
-                    first = f.read().split('\n')[0]
-                    print(f"Read settings file, got {first} - will set counter to start at this number.")
-                    hotkeys_counter.set_counter(int(first))
-
-            else:
-                with open(hotkeys_counter.counter_save_path, 'w+') as f:
-                    f.write('0')
-        except:
-            print("! ERROR: This happened while dealing with the settings file. Will start at 0 and carry on.")
-
+    except Exception as e:
+        print(f"Error loading counter: {e}. Starting at 0")
+        hotkeys_counter.set_counter(0)
 
 def script_properties():
     props = obs.obs_properties_create()
 
-    obs.obs_properties_add_text(
-        props, "counter_text", "Set Counter Text", obs.OBS_TEXT_DEFAULT
+    obs.obs_properties_add_text(props, "counter_save_path", "Counter save directory", obs.OBS_TEXT_DEFAULT)
+    obs.obs_properties_add_text(props, "counter_text", "Text before counter", obs.OBS_TEXT_DEFAULT)
+
+    p = obs.obs_properties_add_list(
+        props, "counter_selection", "Select Counter",
+        obs.OBS_COMBO_TYPE_EDITABLE, obs.OBS_COMBO_FORMAT_STRING
     )
 
-    obs.obs_properties_add_text(
-        props, "counter_save_path", "Set Counter Save Path", obs.OBS_TEXT_DEFAULT
-    )
+    if hasattr(hotkeys_counter, 'counter_save_path') and exists(hotkeys_counter.counter_save_path):
+        try:
+            with open(hotkeys_counter.counter_save_path, "r") as f:
+                counters = [line.split(':')[0].strip() for line in f if ':' in line]
+                for counter in counters:
+                    obs.obs_property_list_add_string(p, counter, counter)
+        except Exception as e:
+            print(f"Error loading counters: {e}")
 
     p1 = obs.obs_properties_add_list(
-        props,
-        "source",
-        "Text Source",
-        obs.OBS_COMBO_TYPE_EDITABLE,
-        obs.OBS_COMBO_FORMAT_STRING,
+        props, "source", "Text Source",
+        obs.OBS_COMBO_TYPE_EDITABLE, obs.OBS_COMBO_FORMAT_STRING
     )
 
     sources = obs.obs_enum_sources()
-
-    if sources is not None:
+    if sources:
         for source in sources:
-            source_id = obs.obs_source_get_unversioned_id(source)
-            if source_id == "text_gdiplus" or source_id == "text_ft2_source":
+            if obs.obs_source_get_unversioned_id(source) in ["text_gdiplus", "text_ft2_source"]:
                 name = obs.obs_source_get_name(source)
                 obs.obs_property_list_add_string(p1, name, name)
-
         obs.source_list_release(sources)
 
     return props


### PR DESCRIPTION
As I would like to have Death Counters for several games in place, I wondered if its possible to reuse this awesome script.
I have implemented a way to select a existing saved counter via the script settings.

How to use:
To create a counter A write a name into the "Select Counter" dropdown/input box.
Use the counter A for some usecases - it will save the value for the counter deedicated for the counter A.
Then create a new counter B the same way and use it.
To switch back to the saved state of counter A go to OBS Scripts again and reload the script. All counter should be available via the dropdown.